### PR TITLE
Update memory.d

### DIFF
--- a/llvm/util/memory.d
+++ b/llvm/util/memory.d
@@ -1,4 +1,3 @@
-
 module llvm.util.memory;
 
 public
@@ -35,7 +34,7 @@ T* construct(T)(size_t length) if(!is(T == class))
 		static T init;
 		foreach(i; 0 .. length)
 		{
-			memcpy(obj[i*size .. (i+1)*size], &init, size);
+			memcpy(obj[i*size .. (i+1)*size].ptr, &init, size);
 		}
 	
 		return cast(T*) obj;


### PR DESCRIPTION
version: dmd v2.063-devel 

```
llvm/util/memory.d(38): Error: function memcpy (void* s1, const(void*) s2, ulong n) is not callable using argument types (void[], char*, ulong)
```

There's another bug somewhere, but it might be in dmd since it triggers [This Assert](https://github.com/D-Programming-Language/dmd/blob/master/src/init.c#L660)  in dmd.

...And I just decided to go ahead and update since I couldn't find any bugs...   =(
