### PR TITLE
fix failed build under dmd2.067: import of 'to' - use std.conv instead of...

### DIFF
--- a/llvm/util/shlib.d
+++ b/llvm/util/shlib.d
@@ -3,7 +3,8 @@ module llvm.util.shlib;
 
 private
 {
-	import std.string : toStringz, to;
+	import std.string : toStringz;
+	import std.conv : to;
 }
 
 version(Posix)


### PR DESCRIPTION
... std.string