### PR TITLE
Update to LLVM 3.6

### DIFF
--- a/llvm/c/constants.d
+++ b/llvm/c/constants.d
@@ -162,6 +162,15 @@ enum : LLVMVisibility
 	LLVMProtectedVisibility
 }
 
+static if(LLVM_Version >= 3.5)
+{
+	enum : LLVMDLLStorageClass {
+		LLVMDefaultStorageClass = 0,
+		LLVMDLLImportStorageClass = 1,
+		LLVMDLLExportStorageClass = 2
+	}
+}
+
 mixin(MixinMap_VersionedEnum(
 			  "", "LLVMCallConv", LLVM_Version,
 			  ["LLVMCCallConv           = 0" : null,
@@ -249,17 +258,44 @@ static if(LLVM_Version >= 3.3)
 		LLVMAtomicRMWBinOpUMin
 	}
 }
+static if(LLVM_Version > 3.5)
+{
+	enum : LLVMDiagnosticSeverity {
+		LLVMDSError,
+		LLVMDSWarning,
+		LLVMDSRemark,
+		LLVMDSNote
+	}
+}
 
 /+ Disassembler +/
 
+//TODO: replace const with enum?
 const
 {
 	uint LLVMDisassembler_VariantKind_None = 0;
 	uint LLVMDisassembler_VariantKind_ARM_HI16 = 1;
 	uint LLVMDisassembler_VariantKind_ARM_LO16 = 2;
+	static if(LLVM_Version >= 3.5)
+	{
+		uint LLVMDisassembler_VariantKind_ARM64_PAGE = 1;
+		uint LLVMDisassembler_VariantKind_ARM64_PAGEOFF = 2;
+		uint LLVMDisassembler_VariantKind_ARM64_GOTPAGE = 3;
+		uint LLVMDisassembler_VariantKind_ARM64_GOTPAGEOFF = 4;
+		uint LLVMDisassembler_VariantKind_ARM64_TLVP = 5;
+		uint LLVMDisassembler_VariantKind_ARM64_TLVOFF = 6;
+	}
 	uint LLVMDisassembler_ReferenceType_InOut_None = 0;
 	uint LLVMDisassembler_ReferenceType_In_Branch = 1;
 	uint LLVMDisassembler_ReferenceType_In_PCrel_Load = 2;
+	static if(LLVM_Version >= 3.5)
+	{
+		uint LLVMDisassembler_ReferenceType_In_ARM64_ADRP = 0x100000001;
+		uint LLVMDisassembler_ReferenceType_In_ARM64_ADDXri = 0x100000002;
+		uint LLVMDisassembler_ReferenceType_In_ARM64_LDRXui = 0x100000003;
+		uint LLVMDisassembler_ReferenceType_In_ARM64_LDRXl = 0x100000004;
+		uint LLVMDisassembler_ReferenceType_In_ARM64_ADR = 0x100000005;
+	}
 	uint LLVMDisassembler_ReferenceType_Out_SymbolStub = 1;
 	uint LLVMDisassembler_ReferenceType_Out_LitPool_SymAddr = 2;
 	uint LLVMDisassembler_ReferenceType_Out_LitPool_CstrAddr = 3;
@@ -274,13 +310,17 @@ const
 	}
 	static if(LLVM_Version >= 3.4)
 	{
-			uint LLVMDisassembler_ReferenceType_Out_Objc_CFString_Ref = 4;
-			uint LLVMDisassembler_ReferenceType_Out_Objc_Message = 5;
-			uint LLVMDisassembler_ReferenceType_Out_Objc_Message_Ref = 6;
-			uint LLVMDisassembler_ReferenceType_Out_Objc_Selector_Ref = 7;
-			uint LLVMDisassembler_ReferenceType_Out_Objc_Class_Ref = 8;
-			uint LLVMDisassembler_Option_SetInstrComments = 8;
-			uint LLVMDisassembler_Option_PrintLatency = 16;
+		uint LLVMDisassembler_ReferenceType_Out_Objc_CFString_Ref = 4;
+		uint LLVMDisassembler_ReferenceType_Out_Objc_Message = 5;
+		uint LLVMDisassembler_ReferenceType_Out_Objc_Message_Ref = 6;
+		uint LLVMDisassembler_ReferenceType_Out_Objc_Selector_Ref = 7;
+		uint LLVMDisassembler_ReferenceType_Out_Objc_Class_Ref = 8;
+		uint LLVMDisassembler_Option_SetInstrComments = 8;
+		uint LLVMDisassembler_Option_PrintLatency = 16;
+	}
+	static if(LLVM_Version >= 3.5)
+	{
+		uint LLVMDisassembler_ReferenceType_DeMangled_Name = 9;
 	}
 }
 
@@ -325,7 +365,11 @@ enum : llvm_lto_status
 
 /+ LTO +/
 
-static if(LLVM_Version >= 3.4)
+static if(LLVM_Version >= 3.5)
+{
+	const uint LTO_API_VERSION = 5;
+}
+else static if(LLVM_Version >= 3.4)
 {
 	const uint LTO_API_VERSION = 5;
 }
@@ -365,7 +409,19 @@ enum : lto_codegen_model
 {
 	LTO_CODEGEN_PIC_MODEL_STATIC = 0,
 	LTO_CODEGEN_PIC_MODEL_DYNAMIC = 1,
-	LTO_CODEGEN_PIC_MODEL_DYNAMIC_NO_PIC = 2
+	LTO_CODEGEN_PIC_MODEL_DYNAMIC_NO_PIC = 2,
+	LTO_CODEGEN_PIC_MODEL_DEFAULT = 3
+}
+
+static if(LLVM_Version >= 3.5)
+{
+	enum : lto_codegen_diagnostic_severity_t
+	{
+		LTO_DS_ERROR = 0,
+		LTO_DS_WARNING = 1,
+	   	LTO_DS_REMARK = 3,
+		LTO_DS_NOTE = 2
+	}
 }
 
 /+ Target information +/

--- a/llvm/c/constants.d
+++ b/llvm/c/constants.d
@@ -343,6 +343,7 @@ static if(LLVM_Version >= 3.2)
 	enum : LLVMLinkerMode
 	{
 		LLVMLinkerDestroySource = 0,
+		//TODO: remove this if LLVM doesn't make it work again?
 		LLVMLinkerPreserveSource = 1
 	}
 }
@@ -365,9 +366,12 @@ enum : llvm_lto_status
 
 /+ LTO +/
 
-static if(LLVM_Version >= 3.5)
+static if(LLVM_Version >= 3.6) {
+	const uinnt LTO_API_VERSION = 11;
+}
+else static if(LLVM_Version >= 3.5)
 {
-	const uint LTO_API_VERSION = 5;
+	const uint LTO_API_VERSION = 10;
 }
 else static if(LLVM_Version >= 3.4)
 {

--- a/llvm/c/functions.d
+++ b/llvm/c/functions.d
@@ -263,6 +263,8 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMWriteBitcodeToFile" : ["int function(LLVMModuleRef M, const(char)* Path)"],
 	"LLVMWriteBitcodeToFD" : ["int function(LLVMModuleRef M, int FD, int ShouldClose, int Unbuffered)"],
 	"LLVMWriteBitcodeToFileHandle" : ["int function(LLVMModuleRef M, int Handle)"],
+	"LLLVMWriteBitcodeToMemoryBuffer": ["LVMMemoryBufferRef function(LLVMModuleRef M)",
+							"+", "3.6"],
 
 	/+ Transforms +/
 
@@ -380,6 +382,8 @@ package enum string[][string] LLVMC_Functions = [
 
 	"LLVMModuleCreateWithName" : ["LLVMModuleRef function(const(char)* ModuleID)"],
 	"LLVMModuleCreateWithNameInContext" : ["LLVMModuleRef function(const(char)* ModuleID, LLVMContextRef C)"],
+	"LLLVMCloneModule": ["LVMModuleRef function(LLVMModuleRef M)",
+					 "+", "3.6"],
 	"LLVMDisposeModule" : ["void function(LLVMModuleRef M)"],
 	"LLVMGetDataLayout" : ["const(char)* function(LLVMModuleRef M)"],
 	"LLVMSetDataLayout" : ["void function(LLVMModuleRef M, const(char)* Triple)"],
@@ -587,6 +591,8 @@ package enum string[][string] LLVMC_Functions = [
 	/+++ User value +++/
 
 	"LLVMGetOperand" : ["LLVMValueRef function(LLVMValueRef Val, uint Index)"],
+	"LLVMGetOperandUse": ["LLVMUseRef function(LLVMValueRef Val, unsigned Index)",
+						  "+", "3.6"],
 	"LLVMSetOperand" : ["void function(LLVMValueRef User, uint Index, LLVMValueRef Val)"],
 	"LLVMGetNumOperands" : ["int function(LLVMValueRef Val)"],
 
@@ -609,15 +615,23 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMConstRealOfStringAndSize" : ["LLVMValueRef function(LLVMTypeRef RealTy, const(char)* Text, uint SLen)"],
 	"LLVMConstIntGetZExtValue" : ["ulong function(LLVMValueRef ConstantVal)"],
 	"LLVMConstIntGetSExtValue" : ["long function(LLVMValueRef ConstantVal)"],
+	"LLVMConstRealGetDouble": ["double function(LLVMValueRef ConstantVal, LLVMBool *losesInfo)",
+							   "+", "3.6"],
 
 	/++++ Composite Constants ++++/
 
 	"LLVMConstStringInContext" : ["LLVMValueRef function(LLVMContextRef C, const(char)* Str, uint Length, LLVMBool DontNullTerminate)"],
 	"LLVMConstString" : ["LLVMValueRef function(const(char)* Str, uint Length, LLVMBool DontNullTerminate)"],
+	"LLVMIsConstantString": ["LLVMBool function(LLVMValueRef c)",
+							 "+", "3.6"],
+	"LLVMGetAsString": ["const(char*) function(LLVMValueRef c, size_t* out)",
+						"+", "3.6"],
 	"LLVMConstStructInContext" : ["LLVMValueRef function(LLVMContextRef C, LLVMValueRef* ConstantVals, uint Count, LLVMBool Packed)"],
 	"LLVMConstStruct" : ["LLVMValueRef function(LLVMValueRef* ConstantVals, uint Count, LLVMBool Packed)"],
 	"LLVMConstArray" : ["LLVMValueRef function(LLVMTypeRef ElementTy, LLVMValueRef* ConstantVals, uint Length)"],
 	"LLVMConstNamedStruct" : ["LLVMValueRef function(LLVMTypeRef StructTy, LLVMValueRef* ConstantVals, uint Count)"],
+	"LLVMGetElementAsConstant": ["LLVMValueRef function(LLVMValueRef c, unsigned idx)",
+								 "+", "3.6"],
 	"LLVMConstVector" : ["LLVMValueRef function(LLVMValueRef* ScalarConstantVals, uint Size)"],
 
 	/++++ Constant Expressions ++++/

--- a/llvm/c/functions.d
+++ b/llvm/c/functions.d
@@ -10,7 +10,7 @@ private
 }
 
 //qualifiers is in the form ["+", "3.3", "-", "3.5"]
-bool matchVersionQualifiers(string[] qualifiers)
+private bool matchVersionQualifiers(string[] qualifiers)
 {
 	while(qualifiers.length > 0)
 	{

--- a/llvm/c/functions.d
+++ b/llvm/c/functions.d
@@ -302,6 +302,8 @@ package enum string[][string] LLVMC_Functions = [
 	/++ Scalar transformations ++/
 
 	"LLVMAddAggressiveDCEPass" : ["void function(LLVMPassManagerRef PM)"],
+	"LLVMAddAlignmentFromAssumptionsPass": ["void function(LLVMPassManagerRef PM)",
+											"+", "3.6"],
 	"LLVMAddCFGSimplificationPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddDeadStoreEliminationPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddScalarizerPass": ["void function(LLVMPassManagerRef PM)",
@@ -323,6 +325,8 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMAddMemCpyOptPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddPartiallyInlineLibCallsPass" : ["void function(LLVMPassManagerRef PM)",
 											"+", "3.4"],
+	"LLVMAddLowerSwitchPass": ["void function(LLVMPassManagerRef PM)",
+							   "+", "3.6"],
 	"LLVMAddPromoteMemoryToRegisterPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddReassociatePass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddSCCPPass" : ["void function(LLVMPassManagerRef PM)"],
@@ -338,6 +342,8 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMAddEarlyCSEPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddLowerExpectIntrinsicPass" : ["void function(LLVMPassManagerRef PM)"],
 	"LLVMAddTypeBasedAliasAnalysisPass" : ["void function(LLVMPassManagerRef PM)"],
+	"LLVMAddScopedNoAliasAAPass": ["void function(LLVMPassManagerRef PM)",
+								   "+", "3.6"],
 	"LLVMAddBasicAliasAnalysisPass" : ["void function(LLVMPassManagerRef PM)"],
 
 	/++ Vectorization transformations ++/
@@ -1148,6 +1154,10 @@ package enum string[][string] LLVMC_Functions = [
 											"+", "3.5"],
 	"LLVMAddGlobalMapping" : ["void function(LLVMExecutionEngineRef EE, LLVMValueRef Global, void* Addr)"],
 	"LLVMGetPointerToGlobal" : ["void* function(LLVMExecutionEngineRef EE, LLVMValueRef Global)"],
+	"LLVMGetGlobalValueAddress": ["ulong function LLVMExecutionEngineRef EE, const char *Name)",
+								  "+", "3.6"],
+	"LLVMGetFunctionAddress": ["ulong function(LLVMExecutionEngineRef EE, const char *Name)",
+							   "+", "3.6"],
 	"LLVMCreateSimpleMCJITMemoryManager" : ["LLVMMCJITMemoryManagerRef function(void* Opaque, LLVMMemoryManagerAllocateCodeSectionCallback AllocateCodeSection, LLVMMemoryManagerAllocateDataSectionCallback AllocateDataSection, LLVMMemoryManagerFinalizeMemoryCallback FinalizeMemory, LLVMMemoryManagerDestroyCallback Destroy)",
 											"+", "3.4"],
 	"LLVMDisposeMCJITMemoryManager" : ["void function(LLVMMCJITMemoryManagerRef MM)",
@@ -1193,6 +1203,11 @@ package enum string[][string] LLVMC_Functions = [
 	"lto_module_create_from_memory" : ["lto_module_t function(const(void)* mem, size_t length)"],
 	"lto_module_create_from_memory_with_path": ["lto_module_t function(const void* mem, size_t length, const char *path)",
 												"+", "3.5"],
+
+	"lto_module_create_in_local_context": ["lto_module_t function(const void *mem, size_t length, const char *path)",
+										   "+", "3.6"],
+	"lto_module_create_in_codegen_context": ["lto_module_t function(const void *mem, size_t length, const char *path, lto_code_gen_t cg)",
+											 "+", "3.6"],
 	"lto_module_create_from_fd" : ["lto_module_t function(int fd, const(char)* path, size_t file_size)"],
 	/+ "offset" is originally of type "off_t", which is 64 bit on 64 bit machines,
 	 + but can be 32 bit or 64 bit on 32 bit machines depending on compilation.
@@ -1221,6 +1236,8 @@ package enum string[][string] LLVMC_Functions = [
 	"lto_codegen_set_diagnostic_handler": ["void function(lto_code_gen_t, lto_diagnostic_handler_t, void *)",
 										   "+", "3.5"],
 	"lto_codegen_create" : ["lto_code_gen_t function()"],
+	"lto_codegen_create_in_local_context": ["lto_code_gen_t function()",
+											"+", "3.6"],
 	"lto_codegen_dispose" : ["void function(lto_code_gen_t)"],
 	"lto_codegen_add_module" : ["bool function(lto_code_gen_t cg, lto_module_t mod)"],
 	"lto_codegen_set_debug_model" : ["bool function(lto_code_gen_t cg, lto_debug_model)"],
@@ -1446,6 +1463,8 @@ package enum string[][string] LLVMC_Functions = [
 	/+ Support +/
 	"LLVMLoadLibraryPermanently" : ["LLVMBool function(const(char)* Filename)",
 									"+", "3.4"],
+	"LLVMParseCommandLineOptions": ["void function(int argc, const char *const *argv, const char *Overview)",
+									"+", "3.6"],
 
 	/+ IRReader +/
 	"LLVMParseIRInContext" : ["LLVMBool function(LLVMContextRef ContextRef, LLVMMemoryBufferRef MemBuf, LLVMModuleRef* OutM, char** OutMessage)",

--- a/llvm/c/functions.d
+++ b/llvm/c/functions.d
@@ -829,6 +829,10 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMInstructionEraseFromParent" : ["void function(LLVMValueRef Inst)"],
 	"LLVMGetInstructionOpcode" : ["LLVMOpcode function(LLVMValueRef Inst)"],
 	"LLVMGetICmpPredicate" : ["LLVMIntPredicate function(LLVMValueRef Inst)"],
+	"LLVMGetFCmpPredicate": ["LLVMRealPredicate function(LLVMValueRef Inst)",
+							 "+", "3.6"],
+	"LLVMInstructionClone": ["LLVMValueRef function(LLVMValueRef Inst)",
+							 "+", "3.6"],
 	"LLVMGetSwitchDefaultDest" : ["LLVMBasicBlockRef function(LLVMValueRef SwitchInstr)"],
 
 	/++++ Call Sites and Invocations ++++/
@@ -840,6 +844,18 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMSetInstrParamAlignment" : ["void function(LLVMValueRef Instr, uint index, uint Align)"],
 	"LLVMIsTailCall" : ["LLVMBool function(LLVMValueRef CallInst)"],
 	"LLVMSetTailCall" : ["void function(LLVMValueRef CallInst, LLVMBool IsTailCall)"],
+	"LLVMGetNumSuccessors": ["uint function(LLVMValueRef Term)",
+							 "+", "3.6"],
+	"LLVMGetSuccessor": ["LLVMBasicBlockRef function(LLVMValueRef Term, unsigned i)",
+						 "+", "3.6"],
+	"LLVMSetSuccessor": ["void function(LLVMValueRef Term, unsigned i, LLVMBasicBlockRef block)",
+						 "+", "3.6"],
+	"LLVMIsConditional": ["LLVMBool function(LLVMValueRef Branch)",
+						  "+", "3.6"],
+	"LLVMGetCondition": ["LLVMValueRef function(LLVMValueRef Branch)",
+						 "+", "3.6"],
+	"LLVMSetCondition": ["void function(LLVMValueRef Branch, LLVMValueRef Cond)",
+						 "+", "3.6"],
 
 	/++++ PHI Nodes ++++/
 
@@ -1011,6 +1027,8 @@ package enum string[][string] LLVMC_Functions = [
 	"LLVMCreateDisasm" : ["LLVMDisasmContextRef function(const(char)* TripleName, void* DisInfo, int TagType, LLVMOpInfoCallback GetOpInfo, LLVMSymbolLookupCallback SymbolLookUp)"],
 	"LLVMCreateDisasmCPU" : ["LLVMDisasmContextRef function(const(char)* Triple, const(char)* CPU, void* DisInfo, int TagType, LLVMOpInfoCallback GetOpInfo, LLVMSymbolLookupCallback SymbolLookUp)",
 	                         "+", "3.3"],
+	"LLVMCreateDisasmCPUFeatures": ["LLVMDisasmContextRef function(const char *Triple, const char *CPU, const char *Features, void *DisInfo, int TagType, LLVMOpInfoCallback GetOpInfo, LLVMSymbolLookupCallback SymbolLookUp)",
+									"+", "3.6"],
 	"LLVMSetDisasmOptions" : ["int function(LLVMDisasmContextRef DC, ulong Options)",
 	                          "+", "3.2"],
 	"LLVMDisasmDispose" : ["void function(LLVMDisasmContextRef DC)"],

--- a/llvm/c/types.d
+++ b/llvm/c/types.d
@@ -22,7 +22,13 @@ struct LLVMOpaquePassManagerBuilder {}; alias LLVMOpaquePassManagerBuilder* LLVM
 
 static if(LLVM_Version >= 3.4)
 {
-		alias extern(C) void function(const char* Reason) LLVMFatalErrorHandler;
+	alias extern(C) void function(const char* Reason) LLVMFatalErrorHandler;
+}
+
+static if(LLVM_Version >= 3.5)
+{
+	alias extern(C) void function(LLVMDiagnosticInfoRef, void*) LLVMDiagnosticHandler;
+	alias extern(C) void function(LLVMContextRef, void *) LLVMYieldCallback;
 }
 
 /++ Types and Enumerations ++/
@@ -35,6 +41,10 @@ struct LLVMOpaqueValue {}; alias LLVMOpaqueValue* LLVMValueRef;
 struct LLVMOpaqueBasicBlock {}; alias LLVMOpaqueBasicBlock* LLVMBasicBlockRef;
 struct LLVMOpaqueBuilder {}; alias LLVMOpaqueBuilder* LLVMBuilderRef;
 struct LLVMOpaqueModuleProvider {}; alias LLVMOpaqueModuleProvider* LLVMModuleProviderRef;
+static if(LLVM_Version >=  3.5)
+{
+	struct LLVMOpaqueDiagnosticInfo {}; alias LLVMOpaqueDiagnosticInfo* LLVMDiagnosticInfoRef;
+}
 struct LLVMOpaqueMemoryBuffer {}; alias LLVMOpaqueMemoryBuffer* LLVMMemoryBufferRef;
 struct LLVMOpaquePassManager {}; alias LLVMOpaquePassManager* LLVMPassManagerRef;
 struct LLVMOpaquePassRegistry {}; alias LLVMOpaquePassRegistry* LLVMPassRegistryRef;
@@ -45,6 +55,7 @@ alias int LLVMOpcode;
 alias int LLVMTypeKind;
 alias int LLVMLinkage;
 alias int LLVMVisibility;
+alias int LLVMDLLStorageClass;
 alias int LLVMCallConv;
 alias int LLVMIntPredicate;
 alias int LLVMRealPredicate;
@@ -54,6 +65,10 @@ static if(LLVM_Version >= 3.3)
 	alias int LLVMThreadLocalMode;
 	alias int LLVMAtomicOrdering;
 	alias int LLVMAtomicRMWBinOp;
+}
+static if(LLVM_Version >= 3.5)
+{
+	alias int LLVMDiagnosticSeverity;
 }
 
 /+ Disassembler +/
@@ -150,12 +165,29 @@ alias int llvm_lto_status;
 
 /+ LTO +/
 
-struct LTOModule {}; alias LTOModule* lto_module_t;
-struct LTOCodeGenerator {}; alias LTOCodeGenerator* lto_code_gen_t;
+static if(LLVM_Version >= 3.5)
+{
+	struct LLVMOpaqueLTOModule {}; alias LLVMOpaqueLTOModule* lto_module_t;
+}
+else
+{
+	struct LTOModule {}; alias LTOModule* lto_module_t;
+}
+static if(LLVM_Version >= 3.5)
+{
+	struct LLVMOpaqueLTOCodeGenerator {}; alias LLVMOpaqueLTOCodeGenerator* lto_code_gen_t;
+}
+else
+{
+	struct LTOCodeGenerator {}; alias LTOCodeGenerator* lto_code_gen_t;
+}
 
 alias int lto_symbol_attributes;
 alias int lto_debug_model;
 alias int lto_codegen_model;
+alias int lto_codegen_diagnostic_severity_t;
+alias extern(C) void function(lto_codegen_diagnostic_severity_t severity,
+		const char *diag, void *ctxt) lto_diagnostic_handler_t;
 
 /+ Object file reading and writing +/
 

--- a/llvm/c/versions.d
+++ b/llvm/c/versions.d
@@ -11,8 +11,10 @@ else version(LLVM_3_2) __gshared immutable string LLVM_VersionString = "3.2";
 else version(LLVM_3_3) __gshared immutable string LLVM_VersionString = "3.3";
 else version(LLVM_3_4) __gshared immutable string LLVM_VersionString = "3.4";
 else version(LLVM_3_5) __gshared immutable string LLVM_VersionString = "3.5";
+//else version(LLVM_3_6) __gshared immutable string LLVM_VersionString = "3.6";
+//else version(LLVM_3_7) __gshared immutable string LLVM_VersionString = "3.7";
 else __gshared immutable string LLVM_VersionString = "3.4";
 
 __gshared immutable float LLVM_Version = to!float(LLVM_VersionString);
 
-__gshared immutable float LLVM_Trunk = 3.5;
+__gshared immutable float LLVM_Trunk = 3.8;

--- a/llvm/c/versions.d
+++ b/llvm/c/versions.d
@@ -11,7 +11,7 @@ else version(LLVM_3_2) __gshared immutable string LLVM_VersionString = "3.2";
 else version(LLVM_3_3) __gshared immutable string LLVM_VersionString = "3.3";
 else version(LLVM_3_4) __gshared immutable string LLVM_VersionString = "3.4";
 else version(LLVM_3_5) __gshared immutable string LLVM_VersionString = "3.5";
-//else version(LLVM_3_6) __gshared immutable string LLVM_VersionString = "3.6";
+else version(LLVM_3_6) __gshared immutable string LLVM_VersionString = "3.6";
 //else version(LLVM_3_7) __gshared immutable string LLVM_VersionString = "3.7";
 else __gshared immutable string LLVM_VersionString = "3.4";
 

--- a/llvm/d/ir/constants.d
+++ b/llvm/d/ir/constants.d
@@ -5,7 +5,7 @@ private
 	import llvm.d.llvm_c;
 
 	import llvm.util.memory;
-	
+
 	import llvm.d.ir.llvmcontext;
 	import llvm.d.ir.type;
 	import llvm.d.ir.derivedtypes;
@@ -36,22 +36,22 @@ class UndefValue : Constant
 		{
 			return this.getSequentialElement();
 		}
-		
+
 		return this.getStructElement((cast(ConstantInt) C).getZExtValue());
 	}+/
-	
+
 	public UndefValue getElementValue(uint Idx)
 	{
 		if(is(this.type : SequentialType))
 		{
 			return this.getSequentialElement();
 		}
-		
+
 		return this.getStructElement(Idx);
 	}
 
 	// virtual void 	destroyConstant ()
-	
+
 	public static UndefValue get(Type T)
 	{ return new UndefValue(T, LLVMGetUndef(T.cref)); }
 }
@@ -219,7 +219,7 @@ class ConstantInt : Constant
 	public static bool isValueValidForType(Type Ty, ulong Val)
 	{
 		uint NumBits = Ty.getIntegerBitWidth(); // assert okay
-		
+
 		if(Ty.isIntegerTy(1))
 		{
 		  return Val == 0 || Val == 1;
@@ -384,7 +384,7 @@ class ConstantStruct : Constant
 		return new ConstantStruct(type, _cref);
 	}
 
-	public static StructType getTypeForElements(Constant V[], bool Packed = false)
+	public static StructType getTypeForElements(Constant[] V, bool Packed = false)
 	in
 	{
 		assert(V.length > 0, "ConstantStruct.getTypeForElements cannot be called on empty list");
@@ -394,7 +394,7 @@ class ConstantStruct : Constant
 		return ConstantStruct.getTypeForElements(V[0].getContext(), V, Packed);
 	}
 
-	public static StructType getTypeForElements(LLVMContext Ctx, Constant V[], bool Packed = false)
+	public static StructType getTypeForElements(LLVMContext Ctx, Constant[] V, bool Packed = false)
 	{
 		Type[] EltTypes;
 		EltTypes.length = V.length;
@@ -478,7 +478,7 @@ class ConstantVector : Constant
 		if((is(V : ConstantFP) || is(V : ConstantInt)) &&
 		   ConstantDataSequential.isElementTypeCompatible(V.getType()))
 		  return ConstantDataVector.getSplat(NumElts, V);
-		
+
 		Constant[] Elts;
 		Elts.length = 32;
 		foreach(i; 0 .. Elts.length)
@@ -670,7 +670,7 @@ class ConstantExpr : Constant
 		{
 			return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstNSWAdd(C1.cref, C2.cref));
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstAdd(C1.cref, C2.cref));
 	}
 
@@ -696,7 +696,7 @@ class ConstantExpr : Constant
 		{
 			return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstNSWSub(C1.cref, C2.cref));
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstSub(C1.cref, C2.cref));
 	}
 
@@ -722,7 +722,7 @@ class ConstantExpr : Constant
 		{
 			return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstNSWMul(C1.cref, C2.cref));
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstMul(C1.cref, C2.cref));
 	}
 
@@ -745,7 +745,7 @@ class ConstantExpr : Constant
 		{
 			return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstExactSDiv(C1.cref, C2.cref));
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(C1.getContext(), LLVMConstSDiv(C1.cref, C2.cref));
 	}
 
@@ -1008,12 +1008,12 @@ class ConstantExpr : Constant
 	public static Constant getGetElementPtr(Constant C, Constant[] IdxList, bool InBounds=false)
 	{
 		LLVMValueRef* IdxListVals = construct!LLVMValueRef(IdxList.length);
-		
+
 		foreach(i; 0 .. IdxList.length)
 		{
 			IdxListVals[i] = IdxList[i].cref;
 		}
-		
+
 		/+ LLVM may either copy the pointers contained in ConstantVals (in which case we
 		 + should deallocate it after the call to the C API), or remember ConstantVals itself
 		 + - by adding it to a map as a value - (in which case we could only deallocate it when
@@ -1032,7 +1032,7 @@ class ConstantExpr : Constant
 		{
 			return cast(Constant) LLVMValueRef_to_Value(C.getContext(), LLVMConstInBoundsGEP(C.cref, IdxListVals, cast(uint) IdxList.length));
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(C.getContext(), LLVMConstGEP(C.cref, IdxListVals, cast(uint) IdxList.length));
 	}
 
@@ -1066,7 +1066,7 @@ class ConstantExpr : Constant
 	public static Constant getExtractValue(Constant Agg, uint[] IdxList)
 	{
 		uint[] IdxListVals = IdxList.dup;
-		
+
 		/+ LLVM may either copy the integers contained in IdxList (in which case we
 		 + should deallocate it after the call to the C API), or remember IdxList itself
 		 + - by adding it to a map as a value - (in which case we could only deallocate it when
@@ -1080,7 +1080,7 @@ class ConstantExpr : Constant
 		{
 			context.treatAsImmutable!uint(IdxListVals);
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(Agg.getContext(), LLVMConstExtractValue(Agg.cref, IdxListVals.ptr, cast(uint) IdxList.length));
 	}
 
@@ -1088,7 +1088,7 @@ class ConstantExpr : Constant
 	public static Constant getInsertValue(Constant Agg, Constant Val, uint[] IdxList)
 	{
 		uint[] IdxListVals = IdxList.dup;
-		
+
 		/+ LLVM may either copy the integers contained in IdxList (in which case we
 		 + should deallocate it after the call to the C API), or remember IdxList itself
 		 + - by adding it to a map as a value - (in which case we could only deallocate it when
@@ -1102,7 +1102,7 @@ class ConstantExpr : Constant
 		{
 			context.treatAsImmutable!uint(IdxListVals);
 		}
-		
+
 		return cast(Constant) LLVMValueRef_to_Value(Agg.getContext(), LLVMConstInsertValue(Agg.cref, Val.cref, IdxListVals.ptr, cast(uint) IdxList.length));
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	],
 	"targetType": "library",
 	"importPaths": ["."],
+	"sourcePaths": ["llvm"],
 	"dependencies": {
 		"llvm-d:c-api": "~master",
 		"llvm-d:d-api": "~master"


### PR DESCRIPTION
This should add LLVM 3.6 support. I haven't tested the new functions, but it compiles just fine.